### PR TITLE
Fixing to work with RN 0.30 and RNSVG 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 react-native-pathjs-charts
 =======================
 
-![](https://img.shields.io/badge/cofi-r&d-brightgreen.svg) [![](https://img.shields.io/badge/react--native-v0.24.1-blue.svg)](https://facebook.github.io/react-native/)
+[![](https://img.shields.io/badge/npm-v0.0.20-brightgreen.svg)](https://www.npmjs.com/package/react-native-pathjs-charts) [![](https://img.shields.io/badge/react--native--svg-3.1.1-blue.svg)](https://www.npmjs.com/package/react-native-svg)  [![](https://img.shields.io/badge/react--native-0.30-orange.svg)](https://facebook.github.io/react-native/)
 [![](https://img.shields.io/badge/android--ff69b4.svg)](http://developer.android.com/sdk/index.html)
 [![](https://img.shields.io/badge/ios--red.svg)](https://developer.apple.com/xcode/)
 [![](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
@@ -31,7 +31,7 @@ To run the example application (from a cloned repo):
 ```
 cd example
 npm install
-rnpm link
+react-native link react-native-svg
 react-native run-ios
 # or
 react-native run-android
@@ -43,7 +43,7 @@ To add the library to your React Native project:
 
 ```
 npm install react-native-pathjs-charts --save
-rnpm link
+react-native link react-native-svg
 ```
 
 ## Usage

--- a/example/package.json
+++ b/example/package.json
@@ -6,8 +6,8 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "^0.14.8",
-    "react-native": "^0.25.1",
+    "react": "^15.3.0",
+    "react-native": "^0.30.0",
     "react-native-pathjs-charts": "file:../"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pathjs-charts",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Cross platform React Native charting library based on path-js and react-native-svg",
   "repository": {
     "type": "git",
@@ -34,10 +34,10 @@
   "dependencies": {
     "lodash": "^4.12.0",
     "paths-js": "^0.3.4",
-    "react-native-svg": "^2.0.0"
+    "react-native-svg": "^3.1.1"
   },
   "devDependencies": {
-    "react": "^0.14.8",
-    "react-native": "^0.24.1"
+    "react": "^15.3.0",
+    "react-native": "^0.30.0"
   }
 }


### PR DESCRIPTION
This fix also includes guidance to link the react-native-svg library directly.

Signed-off-by: Cale Hoopes <caledh@gmail.com>