### PR TITLE
Fix version of react-native-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "lodash": "^4.12.0",
     "paths-js": "^0.3.4",
-    "react-native-svg": "^3.1.1"
+    "react-native-svg": "^4.3.0"
   },
   "devDependencies": {
     "react": "^15.3.0",


### PR DESCRIPTION
The react-native-svg has been updated to compile with last version of react-native (0.34.1).