### PR TITLE
Fix broken example app by upgrading to React Native 0.35 and adding c++ linker flag

### DIFF
--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -659,7 +659,10 @@
 				);
 				INFOPLIST_FILE = example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = example;
 			};
 			name = Debug;
@@ -676,7 +679,10 @@
 				);
 				INFOPLIST_FILE = example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = example;
 			};
 			name = Release;

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "react": "^15.3.0",
-    "react-native": "^0.30.0",
+    "react-native": "^0.35.0",
     "react-native-pathjs-charts": "file:../"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "devDependencies": {
     "react": "^15.3.0",
-    "react-native": "^0.30.0"
+    "react-native": "^0.35.0"
   }
 }


### PR DESCRIPTION
Fixes issue #6 

Adding c++ linker flag was necessary to avoid build errors - [one comment](https://github.com/facebook/react-native/issues/7532#issuecomment-223046991), among several others found, helped address this issue. 