### PR TITLE
Added watchman-update-example-src script to ease manual testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ example/dist
 *.sublime-*
 .idea/
 *.DS_Store
+
+util/watchman-update-example-src/watchman-update-example-src.sh

--- a/README.md
+++ b/README.md
@@ -988,6 +988,14 @@ export default sampleData = {
     }
 }
 ```
+
+## Developing and Testing With The Example App
+
+Please see the [util/watchman-update-example-src/README.md](util/watchman-update-example-src/README.md) for information on how to setup a [Watchman](https://facebook.github.io/watchman/)-based file watch that automates source file copying between [project source](src) and the [example app](example) to make manual testing easier
+
+
+## Contributing
+
 Contributors:
 We welcome your interest in Capital One’s Open Source Projects (the “Project”). Any Contributor to the project must accept and sign a CLA indicating agreement to the license terms. Except for the license granted in this CLA to Capital One and to recipients of software distributed by Capital One, you reserve all right, title, and interest in and to your contributions; this CLA does not impact your rights to use your own contributions for any other purpose.
 

--- a/util/watchman-update-example-src/README.md
+++ b/util/watchman-update-example-src/README.md
@@ -1,0 +1,20 @@
+watchman-update-example-src.sh - Automate file src copies to example app for ease in manual testing
+
+## Intro
+Often when making changes to this charting library, you will want to do some manual testing using the example app included with this project. Often, you will have an emulator up and running and it would be nice if you could see a change in the emulator as soon as you make a change to the charting library. The example app, naturally, looks the source for the "installed" version of this charting package in node_modules (just like any other `npm install`ed package) which means every time you make a change to the chart library source and you want to test with the example app, you have to either `npm install` or manually copy the updated source files into node_modules/react-native-pathjs-charts. Wouldn't it be nice if you didn't have to do this each time? The watchman-update-example-src.sh script in this directory solves this by setting up a watchman watch and trigger that looks for *.js source file changes in `/src` and automatically copies them to `example/node_modules/react-native-pathjs-charts`
+
+
+## Creating the script
+
+From root dir:
+```
+watchman-update-example-src/create-script-from-template.sh
+chmod +x watchman-update-example-src/watchman-update-example-src.sh
+```
+
+## Running the script (only need to do once)
+
+From root dir:
+```
+watchman-update-example-src.sh
+```

--- a/util/watchman-update-example-src/create-script-from-template.sh
+++ b/util/watchman-update-example-src/create-script-from-template.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+WATCH_DIR_ABS_PATH=$(cd "$(dirname "$(pwd)")/../src"; pwd)
+
+sed "s|~~~WATCH_DIR_ABS_PATH~~~|$WATCH_DIR_ABS_PATH|" script-template > watchman-update-example-src.sh

--- a/util/watchman-update-example-src/script-template
+++ b/util/watchman-update-example-src/script-template
@@ -1,0 +1,10 @@
+watchman watch ../../src
+
+watchman -j <<-EOT
+["trigger", "~~~WATCH_DIR_ABS_PATH~~~", {
+  "name": "update-example-src",
+  "expression": ["suffix", "js"],
+  "command": ["xargs", "-n", "1", "-I", "{}", "cp", "{}", "../example/node_modules/react-native-pathjs-charts/src/"],
+  "stdin": "NAME_PER_LINE"
+}]
+EOT


### PR DESCRIPTION
Scripts to setup a [Watchman](https://facebook.github.io/watchman/)-based file watch that automates source file copying between the project source and the example app to make manual testing easier