### PR TITLE
Update react and react-native versions

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,8 +6,8 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "~15.3.0",
-    "react-native": "^0.35.0",
+    "react": "~15.4.0",
+    "react-native": "^0.38.0",
     "react-native-pathjs-charts": "file:../"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-native-svg": "^4.3.0"
   },
   "devDependencies": {
-    "react": "~15.3.0",
-    "react-native": "^0.35.0"
+    "react": "~15.4.0",
+    "react-native": "^0.38.0"
   }
 }


### PR DESCRIPTION
Updating versions to be compatible with the required react-native-svg (4.4.1) version that is being used by react-native-pathjs-charts.