### PR TITLE
Fixed #20 - renders single-item pie chart correctly now

### DIFF
--- a/src/Pie.js
+++ b/src/Pie.js
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and limitations 
 
 import React, {Component} from 'react'
 import {Text as ReactText}  from 'react-native'
-import Svg,{ G, Path, Text} from 'react-native-svg'
+import Svg,{ G, Path, Text, Circle} from 'react-native-svg'
 import { Colors, Options, cyclic, identity, fontAdapt } from './util'
 import _ from 'lodash'
 const Pie = require('paths-js/pie')
@@ -57,7 +57,6 @@ export default class PieChart extends Component {
     }
   }
 
-
   get defaultRange() {
     return _.map(Array(this.props.data && this.props.data.length),function(){return 0})
   }
@@ -68,40 +67,72 @@ export default class PieChart extends Component {
 
     let options = new Options(this.props)
 
-    let x = options.chartWidth / 2
-    let y = options.chartHeight / 2
+    let x = (options.chartWidth / 2) - options.margin.left
+    let y = (options.chartHeight / 2) - options.margin.top
 
     let radius = Math.min(x, y)
 
+    let r = this.props.r
+    r = (isNaN(r) ? (this.props.options && this.props.options.r) : r)
+    r = (isNaN(r) ? (radius / 2) : r)
+
+    let R = this.props.R
+    R = (R || (this.props.options && this.props.options.R))
+    R = (R || radius)
+
     let chart = Pie({
       center: this.props.center || (this.props.options && this.props.options.center) || [0,0] ,
-      r: this.props.r || (this.props.options && this.props.options.r) || radius /2,
-      R: this.props.R || (this.props.options && this.props.options.R) || radius,
+      r,
+      R,
       data: this.props.data,
       accessor: this.props.accessor || identity(this.props.accessorKey)
     })
 
     let textStyle = fontAdapt(options.label)
 
-    let slices = chart.curves.map( (c, i) => {
-      let fill = (c.item.color && Colors.string(c.item.color)) || this.color(i)
-      let stroke = typeof fill === 'string' ? fill : Colors.darkenColor(fill)
-      return (
-                <G key={ i } x={x - options.margin.left} y={y - options.margin.top}>
-                    <Path d={c.sector.path.print() } stroke={stroke} fill={fill} fillOpacity={1}  />
-                    <G x={options.margin.left} y={options.margin.top}>
-                      <Text fontFamily={textStyle.fontFamily}
-                            fontSize={textStyle.fontSize}
-                            fontWeight={textStyle.fontWeight}
-                            fontStyle={textStyle.fontStyle}
-                            fill={textStyle.fill}
-                            textAnchor="middle"
-                            x={c.sector.centroid[0]}
-                            y={c.sector.centroid[1]}>{ c.item.name }</Text>
-                    </G>
-                </G>
-            )
-    })
+    let slices
+
+    if (this.props.data.length === 1) {
+      let item = this.props.data[0]
+      let outerFill = (item.color && Colors.string(item.color)) || this.color(0)
+      let innerFill = this.props.monoItemInnerFillColor || '#fff'
+      let stroke = typeof fill === 'string' ? outerFill : Colors.darkenColor(outerFill)
+      slices = (
+        <G>
+          <Circle r={R} cx={x} cy={y} stroke={stroke} fill={outerFill}/>
+          <Circle r={r} cx={x} cy={y} stroke={stroke} fill={innerFill}/>
+          <Text fontFamily={textStyle.fontFamily}
+                fontSize={textStyle.fontSize}
+                fontWeight={textStyle.fontWeight}
+                fontStyle={textStyle.fontStyle}
+                fill={textStyle.fill}
+                textAnchor="middle"
+                x={x}
+                y={y - R + ((R-r)/2)}>{item.name}</Text>
+        </G>
+      )
+    }
+    else {
+      slices = chart.curves.map( (c, i) => {
+        let fill = (c.item.color && Colors.string(c.item.color)) || this.color(i)
+        let stroke = typeof fill === 'string' ? fill : Colors.darkenColor(fill)
+        return (
+                  <G key={ i } x={x} y={y}>
+                      <Path d={c.sector.path.print() } stroke={stroke} fill={fill} fillOpacity={1}  />
+                      <G x={options.margin.left} y={options.margin.top}>
+                        <Text fontFamily={textStyle.fontFamily}
+                              fontSize={textStyle.fontSize}
+                              fontWeight={textStyle.fontWeight}
+                              fontStyle={textStyle.fontStyle}
+                              fill={textStyle.fill}
+                              textAnchor="middle"
+                              x={c.sector.centroid[0]}
+                              y={c.sector.centroid[1]}>{ c.item.name }</Text>
+                      </G>
+                  </G>
+              )
+      })
+    }
 
     let returnValue = <Svg width={options.width} height={options.height}>
             <G x={options.margin.left} y={options.margin.top}>

--- a/src/__mocks__/react-native-svg.js
+++ b/src/__mocks__/react-native-svg.js
@@ -39,3 +39,9 @@ export const Text = (props) => {
     <view mockedComponent="svg-Text" {...props} />
   )
 }
+
+export const Circle = (props) => {
+  return (
+    <view mockedComponent="svg-Circle" {...props} />
+  )
+}

--- a/src/__tests__/PieBasic-test.js
+++ b/src/__tests__/PieBasic-test.js
@@ -95,3 +95,12 @@ it('contains expected diff between flattened vs non-flattened option usage', () 
   expect(actualAddCount).toBe(expectedAddCount)
 
 })
+
+it('renders with 1 data item correctly', () => {
+  let data = [{"name": "Washington", "population": 7694980}]
+  let tree = renderer.create(
+    <Pie data={data}
+      options={options}/>
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/__tests__/__snapshots__/PieBasic-test.js.snap
+++ b/src/__tests__/__snapshots__/PieBasic-test.js.snap
@@ -207,3 +207,41 @@ exports[`test renders using options property correctly 1`] = `
   </view>
 </view>
 `;
+
+exports[`test renders with 1 data item correctly 1`] = `
+<view
+  mockedComponent="svg-component">
+  <view
+    mockedComponent="svg-G">
+    <view
+      mockedComponent="svg-G">
+      <view
+        cx={155}
+        cy={155}
+        fill="#3199de"
+        mockedComponent="svg-Circle"
+        r={150}
+        stroke="#277ab1" />
+      <view
+        cx={155}
+        cy={155}
+        fill="#fff"
+        mockedComponent="svg-Circle"
+        r={50}
+        stroke="#277ab1" />
+      <view
+        fill="#ECF0F1"
+        fontFamily="Arial"
+        fontSize={8}
+        fontStyle="normal"
+        fontWeight="bold"
+        mockedComponent="svg-Text"
+        textAnchor="middle"
+        x={155}
+        y={55}>
+        Washington
+      </view>
+    </view>
+  </view>
+</view>
+`;


### PR DESCRIPTION
Fixes #20 so that a single-item pie chart renders correctly now.

This was a bit tricky as it was a bit unexpected that an arc with the same start and ending point renders nothing in svg as opposed to rendering a complete circle (which seems more natural from an end-user standpoint but maybe not natural from a pure mathematical standpoint). This issue is discussed in [this StackOverflow question](http://stackoverflow.com/questions/5737975/circle-drawing-with-svgs-arc-path). 

The paths-js library which this library depends on directly to provide the svg paths to draw the pie chart doesn't have any special handling for a complete-circle arc either. So, I took the approach of looking specifically for the scenario where there was only 1 data item and substituting react-native-svg `<Circle>`s - one "outer circle" with a radius of `props.R` and one "inner circle" with a radius of `props.r`.

Along the way I also discovered we weren't probably handling inner radius values of 0 nor fallback logic for either the inner or outer radius. So, I cleaned that up a bit as well.

Also, added a jest test for the single-item pie chart scenario. 
