### PR TITLE
Pinning to patch-updates only for react-native and react-native-svg

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "^15.4.1",
-    "react-native": "^0.38.1",
+    "react-native": "~0.38.1",
     "react-native-pathjs-charts": "file:../",
     "react-native-side-menu": "^0.20.1"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "lodash": "^4.12.0",
     "paths-js": "^0.3.4",
-    "react-native-svg": "^4.4.1"
+    "react-native-svg": "~4.4.1"
   },
   "devDependencies": {
     "babel-jest": "*",
@@ -48,7 +48,7 @@
     "jest": "^18.0.0",
     "jest-react-native": "*",
     "react": "~15.4.1",
-    "react-native": "^0.38.1",
+    "react-native": "~0.38.1",
     "react-test-renderer": "*"
   },
   "jest": {


### PR DESCRIPTION
After attempting to upgrade to newer versions of react-native-svg (and also react-native), I found rendering problems on the charts in the example app:

- When switching to react-native-svg 4.6.1 and react-native 0.40.0, a number of charts replace the (blue colored) grid lines with bold black lines and the radar chart didn't render some of its (blue) lines at all
- Switching to react-native-svg 5.14 (also using  react-native 0.40.0), all of the chart problems above are fixed but then the bar chart is missing its labels due to a new text rotation bug in react-native-svg - https://github.com/react-native-community/react-native-svg/issues/242

Also, unfortunately we are using caret semver ranges in package.json for both react-native and react-native-svg which means that a person cloning this project and doing an `npm install` in the example app for the first time will pull react-native-svg version 4.6.1 rather than 4.4.1. Using tilde ranges will help pin updates on these two key dependencies to patch-level-only updates. This addresses #55 and eliminates the need for extra steps to work around it