### PR TITLE
Fix #63 - adding babelrc config file to example

### DIFF
--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react-native"]
+}


### PR DESCRIPTION
This is intentionally redundant with the .babelrc in the root of the project. The one in example fixes issue #63 when running the example while the one in the root allows `npm test` (jest) to run successfully.