### PR TITLE
Update react-native-svg to be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
   ],
   "dependencies": {
     "lodash": "^4.12.0",
-    "paths-js": "^0.4.5",
-    "react-native-svg": "~4.4.1"
+    "paths-js": "^0.4.5"
+  },
+  "peerDependencies": {
+    "react-native-svg": "4.4.x - 5.1.x"
   },
   "devDependencies": {
     "babel-jest": "*",


### PR DESCRIPTION
Hey,

I updated the react-native-svg dependency to be a peer dependency due to the fact you could have mismatched svg versions and that seems to cause the "d" issue.

https://github.com/capitalone/react-native-pathjs-charts/issues/70

- [x] I have signed the CLA
