### PR TITLE
Fix #103 - cleanup x axis label offsets to avoid tie to chart offsets

### DIFF
--- a/src/Bar.js
+++ b/src/Bar.js
@@ -121,6 +121,7 @@ export default class BarChart extends Component {
                      margin:options.margin}
 
     let textStyle = fontAdapt(options.axisX.label)
+    let labelOffset = this.props.options.axisX.label.offset || 20
 
     let lines = chart.curves.map(function (c, i) {
       let color = this.color(i % 3)
@@ -129,11 +130,12 @@ export default class BarChart extends Component {
                 <G key={'lines' + i}>
                     <Path  d={ c.line.path.print() } stroke={stroke} fill={color}/>
                     {options.axisX.showLabels ?
-                        <G x={options.margin.left} y={options.margin.top}>
                         <Text fontFamily={textStyle.fontFamily}
-                        fontSize={textStyle.fontSize} fontWeight={textStyle.fontWeight} fontStyle={textStyle.fontStyle}
-                        fill={textStyle.fill} x={c.line.centroid[0]} y={chartArea.y.min} rotate={45} textAnchor="middle">{c.item.name}</Text></G>
-                        :null}
+                          fontSize={textStyle.fontSize} fontWeight={textStyle.fontWeight} fontStyle={textStyle.fontStyle}
+                          fill={textStyle.fill} x={c.line.centroid[0]} y={labelOffset + chartArea.y.min} rotate={45} textAnchor="middle">
+                          {c.item.name}
+                        </Text>
+                    : null}
                 </G>
             )
     }, this)


### PR DESCRIPTION
The original (broken) implementation uses a svg group around the x axis
text label. The x and y coordinates for that svg group are driven off
the chart's margin left and top offset values respectively. The
implication of this is that when specifying left and/or top offsets for
the entire chart, it inadvertently makes the labels either not aligned
with its corresponding bars (if the margin left value is too big) or
makes the labels appear way below the x axis or not at all (if the
margin top value is too big).

This fix removes the seemingly unnecessary svg grouping with incorrect
positioning around the label and modifies the y value for the label. The
x value (which is the center of the label) remains positioned at the
center of the bar above that it corresponds with. The y value has been
modified to add a configurable offset value to the minY value for the
chart. If no offset value is configured via the option props the default
offset value is 20 which seems to provide a reasonable amount of spacing
below the x axis.