### PR TITLE
Fixes #134 - allowing bar coloring to respect grouped data

### DIFF
--- a/src/Bar.js
+++ b/src/Bar.js
@@ -124,7 +124,8 @@ export default class BarChart extends Component {
     let labelOffset = this.props.options.axisX.label.offset || 20
 
     let lines = chart.curves.map(function (c, i) {
-      let color = this.color(i % this.props.data.length)
+      let numDataGroups = this.props.data.length || 0
+      let color = this.color(i % numDataGroups)
       let stroke = Colors.darkenColor(color)
       return (
                 <G key={'lines' + i}>

--- a/src/Bar.js
+++ b/src/Bar.js
@@ -124,7 +124,7 @@ export default class BarChart extends Component {
     let labelOffset = this.props.options.axisX.label.offset || 20
 
     let lines = chart.curves.map(function (c, i) {
-      let color = this.color(i % 3)
+      let color = this.color(i % this.props.data.length)
       let stroke = Colors.darkenColor(color)
       return (
                 <G key={'lines' + i}>

--- a/src/Bar.js
+++ b/src/Bar.js
@@ -125,7 +125,8 @@ export default class BarChart extends Component {
 
     let lines = chart.curves.map(function (c, i) {
       let numDataGroups = this.props.data.length || 0
-      let color = this.color(i % numDataGroups)
+      let colorVariationVal = numDataGroups > 1 ? numDataGroups : 3
+      let color = this.color(i % colorVariationVal)
       let stroke = Colors.darkenColor(color)
       return (
                 <G key={'lines' + i}>


### PR DESCRIPTION
Change from hardcoded number (`3`) modded to chose bar color from a 9-color palette to one that targets the length of the number of groups in the input data set (but maintains the color variation if there is just one group as before).
