### PR TITLE
Fix pie chart centering

### DIFF
--- a/src/Pie.js
+++ b/src/Pie.js
@@ -71,8 +71,8 @@ export default class PieChart extends Component {
 
     let options = new Options(this.props)
 
-    let x = (options.chartWidth / 2) - options.margin.left
-    let y = (options.chartHeight / 2) - options.margin.top
+    let x = (options.chartWidth / 2) - (options.margin.left || 0)
+    let y = (options.chartHeight / 2) - (options.margin.top || 0)
 
     let radius = Math.min(x, y)
 
@@ -84,8 +84,10 @@ export default class PieChart extends Component {
     R = (R || (this.props.options && this.props.options.R))
     R = (R || radius)
 
+    let [centerX, centerY] = this.props.center || (this.props.options && this.props.options.center) || [x, y]
+
     let chart = Pie({
-      center: this.props.center || (this.props.options && this.props.options.center) || [0,0] ,
+      center: [centerX, centerY],
       r,
       R,
       data: this.props.data,
@@ -103,16 +105,16 @@ export default class PieChart extends Component {
       let stroke = typeof fill === 'string' ? outerFill : Colors.darkenColor(outerFill)
       slices = (
         <G>
-          <Circle r={R} cx={x} cy={y} stroke={stroke} fill={outerFill}/>
-          <Circle r={r} cx={x} cy={y} stroke={stroke} fill={innerFill}/>
+          <Circle r={R} cx={centerX} cy={centerY} stroke={stroke} fill={outerFill}/>
+          <Circle r={r} cx={centerX} cy={centerY} stroke={stroke} fill={innerFill}/>
           <Text fontFamily={textStyle.fontFamily}
                 fontSize={textStyle.fontSize}
                 fontWeight={textStyle.fontWeight}
                 fontStyle={textStyle.fontStyle}
                 fill={textStyle.fill}
                 textAnchor="middle"
-                x={x}
-                y={y - R + ((R-r)/2)}>{item.name}</Text>
+                x={centerX}
+                y={centerY - R + ((R-r)/2)}>{item.name}</Text>
         </G>
       )
     }
@@ -121,7 +123,7 @@ export default class PieChart extends Component {
         let fill = (c.item.color && Colors.string(c.item.color)) || this.color(i)
         let stroke = typeof fill === 'string' ? fill : Colors.darkenColor(fill)
         return (
-                  <G key={ i } x={x} y={y}>
+                  <G key={ i }>
                       <Path d={c.sector.path.print() } stroke={stroke} fill={fill} fillOpacity={1}  />
                       <G x={options.margin.left} y={options.margin.top}>
                         <Text fontFamily={textStyle.fontFamily}

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -86,14 +86,6 @@ export default class PieChart extends Component {
 
     let [centerX, centerY] = this.props.center || (this.props.options && this.props.options.center) || [x, y]
 
-    let chart = Pie({
-      center: [centerX, centerY],
-      r,
-      R,
-      data: this.props.data,
-      accessor: this.props.accessor || identity(this.props.accessorKey)
-    })
-
     let textStyle = fontAdapt(options.label)
 
     let slices
@@ -117,8 +109,15 @@ export default class PieChart extends Component {
                 y={centerY - R + ((R-r)/2)}>{item.name}</Text>
         </G>
       )
-    }
-    else {
+    } else {
+      let chart = Pie({
+        center: [centerX, centerY],
+        r,
+        R,
+        data: this.props.data,
+        accessor: this.props.accessor || identity(this.props.accessorKey)
+      })
+
       slices = chart.curves.map( (c, i) => {
         let fill = (c.item.color && Colors.string(c.item.color)) || this.color(i)
         let stroke = typeof fill === 'string' ? fill : Colors.darkenColor(fill)


### PR DESCRIPTION
- [x] I have signed the CLA

* Fix NaN x/y values if `options` prop is supplied but does not contain margins
* Fix centering - before this change centering applied two times and `center` option actually meant "x and y shift from the center" instead of "x and y position of the actual center".
* Fix centering if only one data object is provided. Center option was ignored in`this.props.data.length === 1` codepath.
* Do not create actual pie chart object if we have only 1 data object because we render Circle instead.