### PR TITLE
Fix the RN 0.46 and above incompatibility issues caused by React Native SVG 5.2

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "moment": "^2.17.1",
     "react": "16.0.0-alpha.12",
-    "react-native": "0.45.1",
+    "react-native": "~0.46.1",
     "react-native-pathjs-charts": "file:../",
     "react-native-side-menu": "^0.20.1",
     "react-navigation": "^1.0.0-beta.9"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "react-native-svg": "~5.3.0"
   },
   "devDependencies": {
-    "react-native": "0.45.1",
     "babel-jest": "*",
     "babel-preset-react-native": "^1.9.0",
     "diff": "^3.1.0",
@@ -51,6 +50,7 @@
     "jest-react-native": "*",
     "react": "16.0.0-alpha.12",
     "react-dom": "16.0.0-alpha.12",
+    "react-native": "0.45.1",
     "react-test-renderer": "16.0.0-alpha.12"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-polyfill": "^6.23.0",
     "lodash": "^4.12.0",
     "paths-js": "^0.4.5",
-    "react-native-svg": "~5.2.0"
+    "react-native-svg": "~5.3.0"
   },
   "devDependencies": {
     "babel-jest": "*",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest-react-native": "*",
     "react": "16.0.0-alpha.12",
     "react-dom": "16.0.0-alpha.12",
-    "react-native": "0.45.1",
+    "react-native": "~0.46.1",
     "react-test-renderer": "16.0.0-alpha.12"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-test-renderer": "16.0.0-alpha.12"
   },
   "peerDependencies": {
-    "react-native": "0.45.1"
+    "react-native": "^0.45.1"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-native-svg": "~5.3.0"
   },
   "devDependencies": {
+    "react-native": "0.45.1",
     "babel-jest": "*",
     "babel-preset-react-native": "^1.9.0",
     "diff": "^3.1.0",
@@ -51,9 +52,6 @@
     "react": "16.0.0-alpha.12",
     "react-dom": "16.0.0-alpha.12",
     "react-test-renderer": "16.0.0-alpha.12"
-  },
-  "peerDependencies": {
-    "react-native": "^0.45.1"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
     "jest-react-native": "*",
     "react": "16.0.0-alpha.12",
     "react-dom": "16.0.0-alpha.12",
-    "react-native": "0.45.1",
     "react-test-renderer": "16.0.0-alpha.12"
+  },
+  "peerDependencies": {
+    "react-native": "0.45.1"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
Thank you for contributing a pull request. 

Please ensure that you have signed the [CLA](https://docs.google.com/forms/d/19LpBBjykHPox18vrZvBbZUcK6gQTj7qv1O5hCduAZFU/viewform).

- [✓ ] I have signed the CLA
