### PR TITLE
Removed babel-polyfill and substituted with narrower imports

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -43,7 +43,6 @@ import RadarChartBasic from './radar/RadarChartBasic'
 import TreeChartBasic from './tree/TreeChartBasic'
 
 import Home from './Home'
-import 'babel-polyfill'
 
 const styles = StyleSheet.create({
   container: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     }
   ],
   "dependencies": {
-    "babel-polyfill": "^6.23.0",
     "lodash": "^4.12.0",
     "paths-js": "^0.4.5",
     "react-native-svg": "~5.5.1"

--- a/src/Bar.js
+++ b/src/Bar.js
@@ -24,7 +24,6 @@ import _ from 'lodash'
 import Axis from './Axis'
 import GridAxis from './GridAxis'
 const Bar = require('paths-js/bar')
-import 'babel-polyfill'
 
 export default class BarChart extends Component {
 

--- a/src/Pie.js
+++ b/src/Pie.js
@@ -18,7 +18,6 @@ import {Text as ReactText}  from 'react-native'
 import Svg,{ G, Path, Text, Circle} from 'react-native-svg'
 import { Colors, Options, cyclic, identity, fontAdapt } from './util'
 import _ from 'lodash'
-import 'babel-polyfill'
 const Pie = require('paths-js/pie')
 
 export default class PieChart extends Component {

--- a/src/Radar.js
+++ b/src/Radar.js
@@ -21,7 +21,6 @@ import {Text as ReactText}  from 'react-native'
 import Svg,{ G, Path, Line, Text} from 'react-native-svg'
 import { Options, identity, styleSvg, fontAdapt } from './util'
 const Radar = require('paths-js/radar')
-import 'babel-polyfill'
 
 function accessKeys(keys) {
   let a = {}

--- a/src/Scatterplot.js
+++ b/src/Scatterplot.js
@@ -23,7 +23,6 @@ import { Options, styleSvg } from './util'
 import Axis from './Axis'
 import GridAxis from './GridAxis'
 import _ from 'lodash'
-import 'babel-polyfill'
 
 const Stock = require('paths-js/stock')
 

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -22,7 +22,6 @@ import Svg,{ Circle, G, Path, Text } from 'react-native-svg'
 import { Options, styleSvg, fontAdapt } from './util'
 import _ from 'lodash'
 const Tree = require('paths-js/tree')
-import 'babel-polyfill'
 
 function children(x) {
   if(x.collapsed) {

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,9 @@ import SmoothLine from './SmoothLine'
 import StockLine from './StockLine'
 import Scatterplot from './Scatterplot.js'
 
+import 'core-js/es6/symbol'
+import 'core-js/fn/symbol/iterator'
+
 export {
   Pie,
   Tree,


### PR DESCRIPTION
This addresses the great feedback provided by @phillbaker in #173. As he pointed out, this fix should also address #195 and #202 as well. 
