### PR TITLE
feature: add interaction on line chart.

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -31,6 +31,7 @@ import StockLineChartBasic from './stockline/StockLineChartBasic'
 import StockLineChartStaticTickLabels from './stockline/StockLineChartStaticTickLabels'
 import StockLineChartDynamicTickLabels from './stockline/StockLineChartDynamicTickLabels'
 import StockLineChartDynamicLineRendering from './stockline/StockLineChartDynamicLineRendering'
+import StockLineChartGesture from './stockline/StockLineChartGesture'
 
 import SmoothLineChartBasic from './smoothline/SmoothLineChartBasic'
 import SmoothLineChartRegions from './smoothline/SmoothLineChartRegions'
@@ -87,6 +88,10 @@ class HomeScreen extends React.Component {
           title="StockLine - Dynamic Line Rendering"
         />
         <Button
+          onPress={() => navigate('StockLineChartGesture')}
+          title="StockLine - Gesture"
+        />
+        <Button
           onPress={() => navigate('SmoothLineChartBasic')}
           title="SmoothLine - Basic"
         />
@@ -123,6 +128,7 @@ const App = StackNavigator({
   StockLineChartStaticTickLabels: { screen: StockLineChartStaticTickLabels },
   StockLineChartDynamicTickLabels: { screen: StockLineChartDynamicTickLabels },
   StockLineChartDynamicLineRendering: { screen: StockLineChartDynamicLineRendering },
+  StockLineChartGesture: { screen: StockLineChartGesture },
   SmoothLineChartBasic: { screen: SmoothLineChartBasic },
   SmoothLineChartRegions: { screen: SmoothLineChartRegions },
   SmoothLineChartRegionsExtended: { screen: SmoothLineChartRegionsExtended },

--- a/example/src/stockline/StockLineChartGesture.js
+++ b/example/src/stockline/StockLineChartGesture.js
@@ -228,12 +228,12 @@ class StockLineChartBasic extends Component {
 
   _panHandlerStart(cursorPositionX) {
     this.setState({
-      selectedDataPointPosition: String(Math.floor(cursorPositionX * data[0].length))
+      selectedDataPointPosition: String(Math.floor(cursorPositionX * (data[0].length - 1)))
     });
   }
   _panHandlerMove(cursorPositionX) {
     this.setState({
-      selectedDataPointPosition: String(Math.floor(cursorPositionX * data[0].length))
+      selectedDataPointPosition: String(Math.floor(cursorPositionX * (data[0].length - 1)))
     });
   }
   _panHandlerEnd(cursorPositionX) {

--- a/example/src/stockline/StockLineChartGesture.js
+++ b/example/src/stockline/StockLineChartGesture.js
@@ -1,0 +1,314 @@
+/*
+Copyright 2016 Capital One Services, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+
+SPDX-Copyright: Copyright (c) Capital One Services, LLC
+SPDX-License-Identifier: Apache-2.0
+*/
+
+'use strict';
+
+import React, { Component } from 'react';
+import { View, StyleSheet, Text } from 'react-native';
+
+import { StockLine } from 'react-native-pathjs-charts';
+
+const data = [
+  [{
+    "x": 0,
+    "y": 47782
+  }, {
+    "x": 1,
+    "y": 48497
+  }, {
+    "x": 2,
+    "y": 77128
+  }, {
+    "x": 3,
+    "y": 73413
+  }, {
+    "x": 4,
+    "y": 58257
+  }, {
+    "x": 5,
+    "y": 40579
+  }, {
+    "x": 6,
+    "y": 72893
+  }, {
+    "x": 7,
+    "y": 60663
+  }, {
+    "x": 8,
+    "y": 15715
+  }, {
+    "x": 9,
+    "y": 40305
+  }, {
+    "x": 10,
+    "y": 68592
+  }, {
+    "x": 11,
+    "y": 95664
+  }, {
+    "x": 12,
+    "y": 17908
+  }, {
+    "x": 13,
+    "y": 22838
+  }, {
+    "x": 14,
+    "y": 32153
+  }, {
+    "x": 15,
+    "y": 56594
+  }, {
+    "x": 16,
+    "y": 76348
+  }, {
+    "x": 17,
+    "y": 46222
+  }, {
+    "x": 18,
+    "y": 59304
+  }],
+  [{
+    "x": 0,
+    "y": 132189
+  }, {
+    "x": 1,
+    "y": 61705
+  }, {
+    "x": 2,
+    "y": 154976
+  }, {
+    "x": 3,
+    "y": 81304
+  }, {
+    "x": 4,
+    "y": 172572
+  }, {
+    "x": 5,
+    "y": 140656
+  }, {
+    "x": 6,
+    "y": 148606
+  }, {
+    "x": 7,
+    "y": 53010
+  }, {
+    "x": 8,
+    "y": 110783
+  }, {
+    "x": 9,
+    "y": 196446
+  }, {
+    "x": 10,
+    "y": 117057
+  }, {
+    "x": 11,
+    "y": 186765
+  }, {
+    "x": 12,
+    "y": 174908
+  }, {
+    "x": 13,
+    "y": 75247
+  }, {
+    "x": 14,
+    "y": 192894
+  }, {
+    "x": 15,
+    "y": 150356
+  }, {
+    "x": 16,
+    "y": 180360
+  }, {
+    "x": 17,
+    "y": 175697
+  }, {
+    "x": 18,
+    "y": 114967
+  }],
+  [{
+    "x": 0,
+    "y": 125797
+  }, {
+    "x": 1,
+    "y": 256656
+  }, {
+    "x": 2,
+    "y": 222260
+  }, {
+    "x": 3,
+    "y": 265642
+  }, {
+    "x": 4,
+    "y": 263902
+  }, {
+    "x": 5,
+    "y": 113453
+  }, {
+    "x": 6,
+    "y": 289461
+  }, {
+    "x": 7,
+    "y": 293850
+  }, {
+    "x": 8,
+    "y": 206079
+  }, {
+    "x": 9,
+    "y": 240859
+  }, {
+    "x": 10,
+    "y": 152776
+  }, {
+    "x": 11,
+    "y": 297282
+  }, {
+    "x": 12,
+    "y": 175177
+  }, {
+    "x": 13,
+    "y": 169233
+  }, {
+    "x": 14,
+    "y": 237827
+  }, {
+    "x": 15,
+    "y": 242429
+  }, {
+    "x": 16,
+    "y": 218230
+  }, {
+    "x": 17,
+    "y": 161511
+  }, {
+    "x": 18,
+    "y": 153227
+  }]
+];
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f7f7f7',
+  },
+});
+
+class StockLineChartBasic extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  componentWillMount () {
+    this._panHandlerStart = this._panHandlerStart.bind(this);
+    this._panHandlerMove = this._panHandlerStart.bind(this);
+    this._panHandlerEnd = this._panHandlerEnd.bind(this);
+  }
+
+  static navigationOptions = ({ navigation }) => ({
+    title: `StockLine - Gesture`,
+  });
+
+  _panHandlerStart(cursorPositionX) {
+    this.setState({
+      selectedDataPointPosition: String(Math.floor(cursorPositionX * data[0].length))
+    });
+  }
+  _panHandlerMove(cursorPositionX) {
+    this.setState({
+      selectedDataPointPosition: String(Math.floor(cursorPositionX * data[0].length))
+    });
+  }
+  _panHandlerEnd(cursorPositionX) {
+    this.setState({
+      selectedDataPointPosition: ""
+    });
+  }
+
+  render() {
+
+    const options = {
+      width: 250,
+      height: 250,
+      color: '#2980B9',
+      margin: {
+        top: 10,
+        left: 35,
+        bottom: 30,
+        right: 10
+      },
+      animate: {
+        type: 'delayed',
+        duration: 200
+      },
+      axisX: {
+        showAxis: true,
+        showLines: true,
+        showLabels: true,
+        showTicks: true,
+        zeroAxis: false,
+        orient: 'bottom',
+        tickValues: [],
+        label: {
+          fontFamily: 'Arial',
+          fontSize: 8,
+          fontWeight: true,
+          fill: '#34495E'
+        }
+      },
+      axisY: {
+        showAxis: true,
+        showLines: true,
+        showLabels: true,
+        showTicks: true,
+        zeroAxis: false,
+        orient: 'left',
+        tickValues: [],
+        label: {
+          fontFamily: 'Arial',
+          fontSize: 8,
+          fontWeight: true,
+          fill: '#34495E'
+        }
+      },
+      interaction: true,
+      cursorLine: {
+        stroke: 'white',
+        strokeWidth: 2
+      }
+    };
+
+    return (
+      <View style={styles.container}>
+        <Text> Data point index: { this.state.selectedDataPointPosition }</Text>
+        <StockLine
+          panHandlerStart={this._panHandlerStart}
+          panHandlerMove={this._panHandlerMove}
+          panHandlerEnd={this._panHandlerEnd}
+          data={data}
+          options={options}
+          xKey='x'
+          yKey='y' />
+      </View>
+    );
+  }
+}
+
+export default StockLineChartBasic;

--- a/src/Line.js
+++ b/src/Line.js
@@ -96,8 +96,9 @@ export default class LineChart extends Component {
 
       onPanResponderTerminate: (evt, gestureState) => {
 
+        this._calcDataPoint(evt);
         if (this.props.panHandlerEnd) {
-          this.props.panHandlerEnd(evt);
+          this.props.panHandlerEnd(this.curPos);
         }
 
         this.setState({userPressing: false});

--- a/src/SmoothLine.js
+++ b/src/SmoothLine.js
@@ -63,7 +63,12 @@ export default class SmoothLineChart extends LineChart {
           bold: true,
           color: '#34495E'
         }
-      }
+      },
+      cursorLine: {
+        stroke: "white",
+        strokeWidth: "1"
+      },
+      interaction: false
     }
   }
 }

--- a/src/StockLine.js
+++ b/src/StockLine.js
@@ -63,7 +63,12 @@ export default class StockLineChart extends LineChart {
           bold: true,
           color: '#34495E'
         }
-      }
+      },
+      cursorLine: {
+        stroke: "white",
+        strokeWidth: "1"
+      },
+      interaction: false
     }
   }
 }


### PR DESCRIPTION
React-native-pathjs-charts team:

Hey, I was using your chart library for a while. Really handy stock charts to use and I love it.

I worked on chart interaction and tried to implement gesture on line to meet my own project requirement. And I just cleaned it up a little bit and want to share my stuff. This commit add a property `interaction` which default to false. When turn to true. It will response with gesture. 

We can specify call back function in `panHandlerStart`, `panHandlerMove`, `panHandlerEnd`. Each for different stage of gesture.

It also have another feature called `cursorLine` default as `red` color with `width = 1`, which will show as a vertical line on top of the chart as a cursor to indicate while the finger is pressing.

Let me know what you think.

Thank you for contributing a pull request. 

Please ensure that you have signed the [CLA](https://docs.google.com/forms/d/19LpBBjykHPox18vrZvBbZUcK6gQTj7qv1O5hCduAZFU/viewform).

- [x] I have signed the CLA
